### PR TITLE
Add nil check to resourceAuthorizationRead

### DIFF
--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -144,7 +144,7 @@ func resourceAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if *authorizations.Token != "redacted" {
+	if authorizations.Token != nil && *authorizations.Token != "redacted" {
 		err = d.Set("token", authorizations.Token)
 		if err != nil {
 			return err


### PR DESCRIPTION
The resourceAuthorizationRead function will fail, if the authorization was not found by id, because authorizations.Token field is nil in this case.